### PR TITLE
use the error event rather than throwing. What happens then is up to the...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hobknob-client-nodejs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "feature toggle client for node",
   "main": "src/Client.js",
   "scripts": {

--- a/src/Cache.js
+++ b/src/Cache.js
@@ -72,7 +72,8 @@ var setCache = function(self, value){
 Cache.prototype.get = function(toggle){
     var self = this;
     if (!self.cache){
-        throw new Error("Cache not initialized");
+        self.eventEmitter.emit("error", new Error("Cache not initialized. Tried to read toggle: " + toggle));
+        return null;
     }
 
     var value = self.cache[toggle];


### PR DESCRIPTION
... consumer
